### PR TITLE
Update README to reflect latest bypass version in installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add bypass to your list of dependencies in mix.exs:
 
 ```elixir
 def deps do
-  [{:bypass, "~> 0.1", only: :test}]
+  [{:bypass, "~> 0.6", only: :test}]
 end
 ```
 


### PR DESCRIPTION
I was setting up bypass on a project I'm working on and noticed that the version in README was `"~> 0.1"` but the current version is `0.6.0`, so I just updated it with `"~> 0.6"` to handle `0.6.x`.